### PR TITLE
Remove calls to eth_mining

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -336,9 +336,6 @@ Node.prototype.getInfo = function()
 	console.time('Got info');
 
 	try {
-		if (web3.eth.mining) {
-			this.info.coinbase = web3.eth.coinbase;
-		}
 		this.info.node = web3.version.node;
 		this.info.net = web3.version.network;
 		// The method eth_protocolVersion was removed in Geth v1.10.0 and web3
@@ -492,15 +489,11 @@ Node.prototype.getStats = function(forced)
 			},
 			mining: function (callback)
 			{
-				web3.eth.getMining(callback);
+				callback(null, false);
 			},
 			hashrate: function (callback)
 			{
-				if (web3.eth.mining) {
-					web3.eth.getHashrate(callback);
-				} else {
-				    callback(null, 0);
-				}
+				callback(null, 0);
 			},
 			gasPrice: function (callback)
 			{


### PR DESCRIPTION
After the Pectra hard fork activation, the client started to fail with this error:

```
Error: the method eth_mining does not exist/is not available
```

This PR aims to remove every call to that EVM method and restore the status of the clients to operational.